### PR TITLE
Translate 'Installing the Solidity Compiler' into ES

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -2,117 +2,119 @@
 
 .. _installing-solidity:
 
-################################
-Installing the Solidity Compiler
-################################
+####################################
+Instalando el compilador de Solidity
+####################################
 
-Versioning
+Versionado
 ==========
 
-Solidity versions follow `Semantic Versioning <https://semver.org>`_. In
-addition, patch level releases with major release 0 (i.e. 0.x.y) will not
-contain breaking changes. That means code that compiles with version 0.x.y
-can be expected to compile with 0.x.z where z > y.
+Solidity utiliza `Versionado Semántico <https://semver.org/lang/es/>`_. Además, los
+parches publicados con versión 0 (ej. 0.x.y) no contendrán cambios
+con rupturas. Eso significa que si un código compila con una versión 0.x.y 
+puede esperar que compile con una versión 0.x.z donde z > y.
 
-In addition to releases, we provide **nightly development builds** with the
-intention of making it easy for developers to try out upcoming features and
-provide early feedback. Note, however, that while the nightly builds are usually
-very stable, they contain bleeding-edge code from the development branch and are
-not guaranteed to be always working. Despite our best efforts, they might
-contain undocumented and/or broken changes that will not become a part of an
-actual release. They are not meant for production use.
+Adicionalmente a los lanzamientos, proporcionamos **builds nocturnos** con la 
+intención de facilitar a los desarrolladores probar próximas funcionalidades y 
+proveer retroalimentación temprana. Note, sin embargo, que aunque los builds 
+nocturnos son bastante estables, contienen código reciente de la rama de desarrollo
+y no podemos garantizar que siempre funcionen.  A pesar de nuestros mejores
+esfuerzos, pueden contener cambios fallidos o sin documentar que no formarán
+parte del lanzamiento final. No están pensados para uso en producción.
 
-When deploying contracts, you should use the latest released version of Solidity. This
-is because breaking changes, as well as new features and bug fixes are introduced regularly.
-We currently use a 0.x version number `to indicate this fast pace of change <https://semver.org/#spec-item-4>`_.
+Al desplegar contratos, debería usar el último lanzamiento de Solidity. Esto es 
+porque regularmente se introducen cambios con rupturas, funcionalidades nuevas y 
+correcciones de errores. Actualmente usamos un número de versión 0.x 
+`para indicar el rápido ritmo de cambio <https://semver.org/lang/es/#spec-item-4>`_.
 
 Remix
 =====
 
-*We recommend Remix for small contracts and for quickly learning Solidity.*
+*Recomendamos Remix para pequeños contratos y para aprender Solidity rápidamente.*
 
-`Access Remix online <https://remix.ethereum.org/>`_, you do not need to install anything.
-If you want to use it without connection to the Internet, go to
-https://github.com/ethereum/remix-live/tree/gh-pages and download the ``.zip`` file as
-explained on that page. Remix is also a convenient option for testing nightly builds
-without installing multiple Solidity versions.
+`Entre a Remix en línea <https://remix.ethereum.org/>`_, no necesita instalar nada.
+Si quiere usarlo sin conexión a internet, vaya a
+https://github.com/ethereum/remix-live/tree/gh-pages y descargue el archivo ``.zip`` 
+como se explica en la página. Remix también es una buena opción para probar builds
+nocturnos sin instalar múltiples versiones de Solidity.
 
-Further options on this page detail installing commandline Solidity compiler software
-on your computer. Choose a commandline compiler if you are working on a larger contract
-or if you require more compilation options.
+Las siguientes opciones en esta página detallan cómo instalar el software para compilar
+Solidity mediante línea de comandos en su computadora. Use un compilador de línea de comandos 
+si está trabajando en un contrato más largo o si requiere más opciones de compilación.
 
 .. _solcjs:
 
 npm / Node.js
 =============
 
-Use ``npm`` for a convenient and portable way to install ``solcjs``, a Solidity compiler. The
-`solcjs` program has fewer features than the ways to access the compiler described
-further down this page. The
-:ref:`commandline-compiler` documentation assumes you are using
-the full-featured compiler, ``solc``. The usage of ``solcjs`` is documented inside its own
-`repository <https://github.com/ethereum/solc-js>`_.
+Use ``npm`` para instalar ``solcjs``, un compilador de Solidity, de una manera portable 
+y sencilla. El programa `solcjs` tiene menos funcionalidades que el resto de maneras de 
+compilar detalladas más abajo en esta página. La documentación del 
+:ref:`compilador de línea de comandos` asume que está usando el compilador con funcionalidad 
+completa, ``solc``. El uso de ``solcjs`` está documentado dentro de su propio
+`repositorio <https://github.com/ethereum/solc-js>`_.
 
-Note: The solc-js project is derived from the C++
-`solc` by using Emscripten which means that both use the same compiler source code.
-`solc-js` can be used in JavaScript projects directly (such as Remix).
-Please refer to the solc-js repository for instructions.
+Nota: El proyecto solc-js fue extraído del programa `solc` escrito en C++ usando Emscripten, lo
+que significa que ambos usan el mismo código fuente.
+`solc-js` puede usarse directamente en proyectos JavaScript (como Remix).
+Por favor dirígase al repositorio de solc-js para más instrucciones.
 
 .. code-block:: bash
 
     npm install -g solc
 
-.. note::
+.. Nota::
 
-    The commandline executable is named ``solcjs``.
+    El ejecutable de línea de comandos es llamado ``solcjs``.
 
-    The commandline options of ``solcjs`` are not compatible with ``solc`` and tools (such as ``geth``)
-    expecting the behaviour of ``solc`` will not work with ``solcjs``.
+    Las opciones de línea de comandos de ``solcjs`` no son compatibles con ``solc`` y las 
+    herramientas (como ``geth``) que esperen el comportamiento de ``solc`` no funcionarán con ``solcjs``.
 
 Docker
 ======
 
-Docker images of Solidity builds are available using the ``solc`` image from the ``ethereum`` organisation.
-Use the ``stable`` tag for the latest released version, and ``nightly`` for potentially unstable changes in the develop branch.
+Las imágenes de Docker de Solidity están disponibles usando la imagen ``solc`` de la organización ``ethereum``.
+Busque la etiqueta ``stable`` para la versión más reciente, y ``nightly`` para versiones con cambios potencialmente
+inestables de la rama de desarrollo.
 
-The Docker image runs the compiler executable, so you can pass all compiler arguments to it.
-For example, the command below pulls the stable version of the ``solc`` image (if you do not have it already),
-and runs it in a new container, passing the ``--help`` argument.
+La imagen de Docker corre el ejecutable del compilador, así que puede pasarle todos los argumentos del compilador.
+Por ejemplo, el comando de abajo toma la versión estable de la imagen de ``solc`` (si no la tiene todavía),
+y la corre en un contenedor nuevo, pasando el argumento ``--help``.
 
 .. code-block:: bash
 
     docker run ethereum/solc:stable --help
 
-You can also specify release build versions in the tag, for example, for the 0.5.4 release.
+También puede solicitar versiones de lanzamientos específicas, por ejemplo la versión 0.5.4.
 
 .. code-block:: bash
 
     docker run ethereum/solc:0.5.4 --help
 
-To use the Docker image to compile Solidity files on the host machine mount a
-local folder for input and output, and specify the contract to compile. For example.
+Para usar una imagen de Docker para compilar archivos Solidity en la máquina huésped, monte 
+una carpeta local para entrada y salida, y especifique el contrato a compilar. Por ejemplo.
 
 .. code-block:: bash
 
     docker run -v /local/path:/sources ethereum/solc:stable -o /sources/output --abi --bin /sources/Contract.sol
 
-You can also use the standard JSON interface (which is recommended when using the compiler with tooling).
-When using this interface it is not necessary to mount any directories as long as the JSON input is
-self-contained (i.e. it does not refer to any external files that would have to be
-:ref:`loaded by the import callback <initial-vfs-content-standard-json-with-import-callback>`).
+También puede usar la interfaz standard de JSON (que es la recomendada cuando se usa el compilador con otras 
+herramientas). Cuando use esta interfaz, no es necesario montar ningún directorio mientras el input de JSON sea 
+autocontenido (ej. cuando no haga referencia a archivos externos que tendrían que ser cargados con un
+:ref:`import callback <initial-vfs-content-standard-json-with-import-callback>`).
 
 .. code-block:: bash
 
     docker run ethereum/solc:stable --standard-json < input.json > output.json
 
-Linux Packages
-==============
+Paquetes de Linux
+=================
 
-Binary packages of Solidity are available at
+Los binarios de Solidity están disponibles en
 `solidity/releases <https://github.com/ethereum/solidity/releases>`_.
 
-We also have PPAs for Ubuntu, you can get the latest stable
-version using the following commands:
+También tenemos PPAs para Ubuntu, puede obtener la versión estable más 
+reciente usando los siguientes comandos:
 
 .. code-block:: bash
 
@@ -120,7 +122,7 @@ version using the following commands:
     sudo apt-get update
     sudo apt-get install solc
 
-The nightly version can be installed using these commands:
+La versión nocturna puede ser instalada usando estos comandos:
 
 .. code-block:: bash
 
@@ -129,43 +131,45 @@ The nightly version can be installed using these commands:
     sudo apt-get update
     sudo apt-get install solc
 
-Furthermore, some Linux distributions provide their own packages. These packages are not directly
-maintained by us, but usually kept up-to-date by the respective package maintainers.
+Más aún, algunas distribuciones de Linux proveen sus propios paquetes. Estos paquetes no
+son mantenidos directamente por nosotros, sino por los desarrolladores de dichos paquetes.
 
-For example, Arch Linux has packages for the latest development version:
+Por ejemplo, Arch Linux tiene paquetes para la última versión de desarrollo:
 
 .. code-block:: bash
 
     pacman -S solidity
 
-There is also a `snap package <https://snapcraft.io/solc>`_, however, it is **currently unmaintained**.
-It is installable in all the `supported Linux distros <https://snapcraft.io/docs/core/install>`_. To
-install the latest stable version of solc:
+También hay un `paquete para snap <https://snapcraft.io/solc>`_, 
+sin embargo actualmente **no se le da mantenimiento**. Se puede instalar en todas las
+`distros de Linux respaldadas <https://snapcraft.io/docs/core/install>`_. Para instalar
+la última versión estable de solc:
 
 .. code-block:: bash
 
     sudo snap install solc
 
-If you want to help testing the latest development version of Solidity
-with the most recent changes, please use the following:
+Si usted quiere ayudar a probar la última versión de desarrollo de Solidity 
+con los cambios más recientes, por favor utilice el siguiente comando:
 
 .. code-block:: bash
 
     sudo snap install solc --edge
 
-.. note::
+.. Nota::
 
-    The ``solc`` snap uses strict confinement. This is the most secure mode for snap packages
-    but it comes with limitations, like accessing only the files in your ``/home`` and ``/media`` directories.
-    For more information, go to `Demystifying Snap Confinement <https://snapcraft.io/blog/demystifying-snap-confinement>`_.
+    El snap de ``solc`` usa confinamiento estricto. Este es el modo más seguro para paquetes
+    de snap pero tiene sus limitaciones, como por ejemplo, el sólo acceder a los archivos en sus
+    directorios ``/home`` y ``/media``.
+    Para más información, vaya a `Demystifying Snap Confinement <https://snapcraft.io/blog/demystifying-snap-confinement>`_.
 
 
-macOS Packages
-==============
+Paquetes para macOs
+===================
 
-We distribute the Solidity compiler through Homebrew
-as a build-from-source version. Pre-built bottles are
-currently not supported.
+Distribuimos el compilador de Solidity a través de Homebrew
+como una versión build-from-source. Los binarios pre-compilados
+no son respaldados actualmente.
 
 .. code-block:: bash
 
@@ -174,62 +178,65 @@ currently not supported.
     brew tap ethereum/ethereum
     brew install solidity
 
-To install the most recent 0.4.x / 0.5.x version of Solidity you can also use ``brew install solidity@4``
-and ``brew install solidity@5``, respectively.
+Para instalar la versión 0.4.x / 0.5.x más reciente de Solidity también puede usar 
+``brew install solidity@4`` y ``brew install solidity@5``, respectivamente.
 
-If you need a specific version of Solidity you can install a
-Homebrew formula directly from Github.
+Si necesita una versión específica de Solidity puede instalar una 
+fórmula de Homebrew directamente desde Github.
 
-View
-`solidity.rb commits on Github <https://github.com/ethereum/homebrew-ethereum/commits/master/solidity.rb>`_.
+Ver
+`commits de solidity.rb en Github <https://github.com/ethereum/homebrew-ethereum/commits/master/solidity.rb>`_.
 
-Copy the commit hash of the version you want and check it out on your machine.
+Copie el commit hash de la versión que quiere y haga check out en su máquina.
 
 .. code-block:: bash
 
     git clone https://github.com/ethereum/homebrew-ethereum.git
     cd homebrew-ethereum
-    git checkout <your-hash-goes-here>
+    git checkout <el-hash-va-aquí>
 
-Install it using ``brew``:
+Instalar usando ``brew``:
 
 .. code-block:: bash
 
     brew unlink solidity
-    # eg. Install 0.4.8
+    # ej. para instalar 0.4.8
     brew install solidity.rb
 
-Static Binaries
-===============
+Binarios estáticos
+==================
 
-We maintain a repository containing static builds of past and current compiler versions for all
-supported platforms at `solc-bin`_. This is also the location where you can find the nightly builds.
+Mantenemos un repositorio con todos los binarios estáticos y versiones actuales del compilador 
+para todas las plataformas respaldadas en `solc-bin`_. En esta locación también puede encontrar
+las compilaciones nocturnas.
 
-The repository is not only a quick and easy way for end users to get binaries ready to be used
-out-of-the-box but it is also meant to be friendly to third-party tools:
+Este repositorio no es solamente una manera fácil y rápida para que los usuarios finales puedan
+obtener los archivos binarios listos para usarse; también está pensado para ser amigable para
+herramientas de terceros:
 
-- The content is mirrored to https://binaries.soliditylang.org where it can be easily downloaded over
-  HTTPS without any authentication, rate limiting or the need to use git.
-- Content is served with correct `Content-Type` headers and lenient CORS configuration so that it
-  can be directly loaded by tools running in the browser.
-- Binaries do not require installation or unpacking (with the exception of older Windows builds
-  bundled with necessary DLLs).
-- We strive for a high level of backwards-compatibility. Files, once added, are not removed or moved
-  without providing a symlink/redirect at the old location. They are also never modified
-  in place and should always match the original checksum. The only exception would be broken or
-  unusable files with a potential to cause more harm than good if left as is.
-- Files are served over both HTTP and HTTPS. As long as you obtain the file list in a secure way
-  (via git, HTTPS, IPFS or just have it cached locally) and verify hashes of the binaries
-  after downloading them, you do not have to use HTTPS for the binaries themselves.
+- El contenido está respaldado en https://binaries.soliditylang.org donde puede ser descargado
+  por HTTPS sin autenticación, limitaciones de velocidad o la necesidad de usar git.
+- El contenido es servido con las cabeceras de tipo `Content-Type` correctas y una configuración 
+  de CORS permisiva para que pueda ser cargado directamente por herramientas que corran en navegadores.
+- Los binarios no requieren instalación o desempaquetado (con la excepción de algunas compilaciones
+  antiguas para Windows que vienen con DLLs necesarios).
+- Nos esforzamos por una alta compatibilidad con versiones anteriores. Una vez que añadimos un archivo,
+  no lo movemos o borramos sin proveer un symlink/redirect a la locación anterior. Nunca los modificamos
+  en su lugar y el checksum siempre debería coincidir. La única excepción es con archivos dañados o 
+  corrompidos que potencialmente podrían causar más daño de dejarse como están.
+- Los archivos son servidos por HTTP y HTTPS. Mientras obtenga la lista de archivos de manera segura
+  (via git, HTTPS, IPFS o esté cacheado localmente) y verifique los hashes de los binarios después de
+  descargarlos, no necesita usar HTTPS para los binarios en sí mismos.
 
-The same binaries are in most cases available on the `Solidity release page on Github`_. The
-difference is that we do not generally update old releases on the Github release page. This means
-that we do not rename them if the naming convention changes and we do not add builds for platforms
-that were not supported at the time of release. This only happens in ``solc-bin``.
+Los mismos binarios están disponibles la mayoría de las ocasiones en la `página de releases de Solidity en Gihtub`_.
+La diferencia es que normalmente no actualizamos viejos releases en esa página. Eso significa
+que no los renombramos si las convenciones para nombrar archivos cambian, y tampoco añadimos 
+compilaciones para plataformas que no estaban disponibles cuando se hizo el release. Esto solo sucede
+en ``solc-bin``.
 
-The ``solc-bin`` repository contains several top-level directories, each representing a single platform.
-Each one contains a ``list.json`` file listing the available binaries. For example in
-``emscripten-wasm32/list.json`` you will find the following information about version 0.7.4:
+El repositorio de ``solc-bin`` contiene varios directorios de primer nivel, cada uno representando una plataforma. 
+Cada uno contiene un archivo ``list.json`` que enlista los binarios disponibles. Por ejemplo, en
+``emscripten-wasm32/list.json`` encontrará la siguiente información sobre la versión 0.7.4:
 
 .. code-block:: json
 
@@ -246,89 +253,91 @@ Each one contains a ``list.json`` file listing the available binaries. For examp
       ]
     }
 
-This means that:
+Esto significa que:
 
-- You can find the binary in the same directory under the name
+- Puede encontrar el binario en el mismo directorio bajo el nombre
   `solc-emscripten-wasm32-v0.7.4+commit.3f05b770.js <https://github.com/ethereum/solc-bin/blob/gh-pages/emscripten-wasm32/solc-emscripten-wasm32-v0.7.4+commit.3f05b770.js>`_.
-  Note that the file might be a symlink, and you will need to resolve it yourself if you are not using
-  git to download it or your file system does not support symlinks.
-- The binary is also mirrored at https://binaries.soliditylang.org/emscripten-wasm32/solc-emscripten-wasm32-v0.7.4+commit.3f05b770.js.
-  In this case git is not necessary and symlinks are resolved transparently, either by serving a copy
-  of the file or returning a HTTP redirect.
-- The file is also available on IPFS at `QmTLs5MuLEWXQkths41HiACoXDiH8zxyqBHGFDRSzVE5CS`_.
-- The file might in future be available on Swarm at `16c5f09109c793db99fe35f037c6092b061bd39260ee7a677c8a97f18c955ab1`_.
-- You can verify the integrity of the binary by comparing its keccak256 hash to
-  ``0x300330ecd127756b824aa13e843cb1f43c473cb22eaf3750d5fb9c99279af8c3``.  The hash can be computed
-  on the command line using ``keccak256sum`` utility provided by `sha3sum`_ or `keccak256() function
-  from ethereumjs-util`_ in JavaScript.
-- You can also verify the integrity of the binary by comparing its sha256 hash to
+  Note que el archivo puede ser un symlink, y necesitará resolverlo usted mismo si no está usando
+  git para bajarlo a su sistema de archivos o su sistema de archivos no soporta symlinks.
+- El binario también está respaldado en https://binaries.soliditylang.org/emscripten-wasm32/solc-emscripten-wasm32-v0.7.4+commit.3f05b770.js.
+  En este caso no se necesita git y los symlinks son resueltos transparentemente, ya sea sirviendo una copia del
+  archivo o regresando una redirección de HTTP.
+- El archivo también está disponible en IPFS en `QmTLs5MuLEWXQkths41HiACoXDiH8zxyqBHGFDRSzVE5CS`_.
+- El archivo puede estar disponible en Swarm en un futuro en `16c5f09109c793db99fe35f037c6092b061bd39260ee7a677c8a97f18c955ab1`_.
+- Usted puede verificar la integridad del binario comparando su hash keccak256 con 
+  ``0x300330ecd127756b824aa13e843cb1f43c473cb22eaf3750d5fb9c99279af8c3``. El hash puede 
+  ser computado en la línea de comandos usando la utilería ``keccak256sum`` que provee `sha3sum`_ 
+  o la `función keccak256() de ethereumjs-util`_ en JavaScript.
+- Usted también puede verificar la integridad del binario comparando su hash sha256 con
   ``0x2b55ed5fec4d9625b6c7b3ab1abd2b7fb7dd2a9c68543bf0323db2c7e2d55af2``.
 
-.. warning::
+.. Advertencia::
 
-   Due to the strong backwards compatibility requirement the repository contains some legacy elements
-   but you should avoid using them when writing new tools:
+   Debido a los fuertes requerimientos de compatibilidad con versiones anteriores, el repositorio 
+   contiene algunos elementos descontinuados que debería evitar usar al crear herramientas nuevas: 
+   
+   - Use ``emscripten-wasm32/`` (o en su defecto ``emscripten-asmjs/``) en lugar de ``bin/`` si 
+     quiere el mejor rendimiento. Hasta la versión 0.6.1 sólo proveíamos binarios de asm.js.
+     A partir de la versión 0.6.2 hicimos el cambio a `WebAssembly builds`_ que tiene mucho mejor 
+     rendimiento. Hemos recompilado las versiones más antiguas para wasm pero los archivos originales 
+     asm.js se mantienen en ``bin/``. Los nuevos tuvieron que ser puestos en un directorio separado 
+     para evitar conflictos de nombramiento.
+   - Use los directorios ``emscripten-asmjs/`` y ``emscripten-wasm32/`` en lugar de ``bin/`` y ``wasm/``
+     si quiere estar seguro de si está descargando un binario de wasm o de asm.js. 
+   - Use ``list.json`` en vez de ``list.js`` y ``list.txt``. El formato JSON contiene toda la 
+     información de los binarios antiguos y más.
+   - Use https://binaries.soliditylang.org en vez de https://solc-bin.ethereum.org. Para mantener 
+     las cosas simples, movimos casi todo lo relacionado al compilador al nuevo dominio 
+     ``soliditylang.org`` y esto también aplica para ``solc-bin``. Aunque recomendamos el nuevo 
+     dominio, el antiguo sigue siendo mantenido y se garantiza que apunte a la misma locación.
 
-   - Use ``emscripten-wasm32/`` (with a fallback to ``emscripten-asmjs/``) instead of ``bin/`` if
-     you want the best performance. Until version 0.6.1 we only provided asm.js binaries.
-     Starting with 0.6.2 we switched to `WebAssembly builds`_ with much better performance. We have
-     rebuilt the older versions for wasm but the original asm.js files remain in ``bin/``.
-     The new ones had to be placed in a separate directory to avoid name clashes.
-   - Use ``emscripten-asmjs/`` and ``emscripten-wasm32/`` instead of ``bin/`` and ``wasm/`` directories
-     if you want to be sure whether you are downloading a wasm or an asm.js binary.
-   - Use ``list.json`` instead of ``list.js`` and ``list.txt``. The JSON list format contains all
-     the information from the old ones and more.
-   - Use https://binaries.soliditylang.org instead of https://solc-bin.ethereum.org. To keep things
-     simple we moved almost everything related to the compiler under the new ``soliditylang.org``
-     domain and this applies to ``solc-bin`` too. While the new domain is recommended, the old one
-     is still fully supported and guaranteed to point at the same location.
+.. Advertencia::
 
-.. warning::
+    Los binarios también están disponbiles en https://ethereum.github.io/solc-bin/ pero esta página
+    dejó de ser actualizada justo después del lanzamiento de la versión 0.7.2, no va a recibir 
+    nuevos releases ni compilaciones nocturnas para ninguna plataforma y no sirve la nueva estructura
+    del directorio, incluyendo compilaciones no-emscripten.
 
-    The binaries are also available at https://ethereum.github.io/solc-bin/ but this page
-    stopped being updated just after the release of version 0.7.2, will not receive any new releases
-    or nightly builds for any platform and does not serve the new directory structure, including
-    non-emscripten builds.
-
-    If you are using it, please switch to https://binaries.soliditylang.org, which is a drop-in
-    replacement. This allows us to make changes to the underlying hosting in a transparent way and
-    minimize disruption. Unlike the ``ethereum.github.io`` domain, which we do not have any control
-    over, ``binaries.soliditylang.org`` is guaranteed to work and maintain the same URL structure
-    in the long-term.
+    Si usted la está usando, por favor cambie a https://binaries.soliditylang.org, que es su reemplazo.
+    Esto nos permite hacerle cambios al hosting subyacente de una manera transparente y minimizar
+    disrupciones. Al contrario del dominio ``ethereum.github.io``, el cual no controlamos, 
+    ``binaries.soliditylang.org`` está garantizado para funcionar y mantener la misma estructura de URLs 
+    en el largo plazo.
 
 .. _IPFS: https://ipfs.io
 .. _Swarm: https://swarm-gateways.net/bzz:/swarm.eth
 .. _solc-bin: https://github.com/ethereum/solc-bin/
-.. _Solidity release page on github: https://github.com/ethereum/solidity/releases
+.. _página de releases de Solidity en Gihtub: https://github.com/ethereum/solidity/releases
 .. _sha3sum: https://github.com/maandree/sha3sum
-.. _keccak256() function from ethereumjs-util: https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_hash_.md#const-keccak256
+.. _función keccak256() de ethereumjs-util: https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_hash_.md#const-keccak256
 .. _WebAssembly builds: https://emscripten.org/docs/compiling/WebAssembly.html
 .. _QmTLs5MuLEWXQkths41HiACoXDiH8zxyqBHGFDRSzVE5CS: https://gateway.ipfs.io/ipfs/QmTLs5MuLEWXQkths41HiACoXDiH8zxyqBHGFDRSzVE5CS
 .. _16c5f09109c793db99fe35f037c6092b061bd39260ee7a677c8a97f18c955ab1: https://swarm-gateways.net/bzz:/16c5f09109c793db99fe35f037c6092b061bd39260ee7a677c8a97f18c955ab1/
 
-.. _building-from-source:
+.. _compilando-del-codigo-fuente:
 
-Building from Source
-====================
+Compilando del código fuente
+============================
 
-Prerequisites - All Operating Systems
--------------------------------------
+Prerrequisitos - Todos los Sistemas Operativos
+----------------------------------------------
 
-The following are dependencies for all builds of Solidity:
+A continuación las dependencias para todas las compilaciones de Solidity:
 
 +-----------------------------------+-------------------------------------------------------+
-| Software                          | Notes                                                 |
+| Software                          | Notas                                                 |
 +===================================+=======================================================+
-| `CMake`_ (version 3.13+)          | Cross-platform build file generator.                  |
+| `CMake`_ (version 3.13+)          | Generadord de código fuente multiplataforma.          |
 +-----------------------------------+-------------------------------------------------------+
-| `Boost`_ (version 1.77+ on        | C++ libraries.                                        |
-| Windows, 1.65+ otherwise)         |                                                       |
+| `Boost`_ (version 1.77+ en        | Librerías de C++.                                     |
+| Windows, 1.65+ en otros)          |                                                       |
 +-----------------------------------+-------------------------------------------------------+
-| `Git`_                            | Command-line tool for retrieving source code.         |
+| `Git`_                            | Software de línea de comandos para obtener código     |
+|                                   | fuente.                                               |
 +-----------------------------------+-------------------------------------------------------+
-| `z3`_ (version 4.8+, Optional)    | For use with SMT checker.                             |
+| `z3`_ (versión 4.8+, Opcional)    | Para usar con SMT checker.                            |
 +-----------------------------------+-------------------------------------------------------+
-| `cvc4`_ (Optional)                | For use with SMT checker.                             |
+| `cvc4`_ (Opcional)                | Para usar con SMT checker.                            |
 +-----------------------------------+-------------------------------------------------------+
 
 .. _cvc4: https://cvc4.cs.stanford.edu/web/
@@ -337,78 +346,79 @@ The following are dependencies for all builds of Solidity:
 .. _CMake: https://cmake.org/download/
 .. _z3: https://github.com/Z3Prover/z3
 
-.. note::
-    Solidity versions prior to 0.5.10 can fail to correctly link against Boost versions 1.70+.
-    A possible workaround is to temporarily rename ``<Boost install path>/lib/cmake/Boost-1.70.0``
-    prior to running the cmake command to configure solidity.
+.. Nota::
+    Las versiones de Solidity anteriores a la 0.5.10 pueden no funcionar correctamente con 
+    versiones de Boost 1.70+. Una posible solución es renombrar temporalmente 
+    ``<Boost install path>/lib/cmake/Boost-1.70.0`` antes de correr el comando de cmake para 
+    configurar Solidity.
 
-    Starting from 0.5.10 linking against Boost 1.70+ should work without manual intervention.
+    A partir de la versión 0.5.10, debería funcionar correctamente con las versiones de Boost 
+    1.70+ sin necesidad de ajustes manuales.
 
-.. note::
-    The default build configuration requires a specific Z3 version (the latest one at the time the
-    code was last updated). Changes introduced between Z3 releases often result in slightly different
-    (but still valid) results being returned. Our SMT tests do not account for these differences and
-    will likely fail with a different version than the one they were written for. This does not mean
-    that a build using a different version is faulty. If you pass ``-DSTRICT_Z3_VERSION=OFF`` option
-    to CMake, you can build with any version that satisfies the requirement given in the table above.
-    If you do this, however, please remember to pass the ``--no-smt`` option to ``scripts/tests.sh``
-    to skip the SMT tests.
+.. Nota::
+    La configuración de la compilación por defecto requiere una versión de Z3 específica (la última 
+    en el momento que el código se actualizó por última vez). Los cambios que hay entre versiones de
+    Z3 generalmente dan como resultado lanzamientos ligeramente distintos (pero válidos). Nuestras
+    pruebas SMT no toman en cuenta estas diferencias y probablemente fallarán con una versión diferente 
+    de la versión para la que fueron escritas. Esto no significa que una compilación que use una 
+    versión diferente está dañada. Si usted pasa la opción ``-DSTRICT_Z3_VERSION=OFF`` a CMake, puede
+    compilar con cualquier versión que satisfaga los requerimientos de la tabla de arriba. Si hace esto,
+    sin embargo, recuerde pasar la opción ``--no-smt`` a ``scripts/tests.sh`` para saltar las pruebas SMT.
 
-Minimum Compiler Versions
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Versiones Mínimas del Compilador
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following C++ compilers and their minimum versions can build the Solidity codebase:
+Los siguientes compiladores de C++ y sus versiones mínimas pueden compilar el código de Solidity:
 
-- `GCC <https://gcc.gnu.org>`_, version 8+
-- `Clang <https://clang.llvm.org/>`_, version 7+
-- `MSVC <https://visualstudio.microsoft.com/vs/>`_, version 2019+
+- `GCC <https://gcc.gnu.org>`_, versión 8+
+- `Clang <https://clang.llvm.org/>`_, versión 7+
+- `MSVC <https://visualstudio.microsoft.com/vs/>`_, versión 2019+
 
-Prerequisites - macOS
----------------------
+Prerrequisitos - macOS
+----------------------
 
-For macOS builds, ensure that you have the latest version of
-`Xcode installed <https://developer.apple.com/xcode/download/>`_.
-This contains the `Clang C++ compiler <https://en.wikipedia.org/wiki/Clang>`_, the
-`Xcode IDE <https://en.wikipedia.org/wiki/Xcode>`_ and other Apple development
-tools that are required for building C++ applications on OS X.
-If you are installing Xcode for the first time, or have just installed a new
-version then you will need to agree to the license before you can do
-command-line builds:
+Para compilar en macOS, asegúrese que tenga la versión más reciente de 
+`Xcode instalada <https://developer.apple.com/xcode/download/>`_.
+Ésta contiene el `compilador Clang C++ <https://en.wikipedia.org/wiki/Clang>`_,
+el `IDE de Xcode <https://en.wikipedia.org/wiki/Xcode>`_ y otras herramientas de 
+desarrollo de Apple que se requieren para compilar aplicaciones C++ en OS X.
+Si está instalando Xcode por primera vez, o acaba de instalar una nueva versión 
+necesitará aceptar la licencia antes de poder compilar desde la línea de comandos:
 
 .. code-block:: bash
 
     sudo xcodebuild -license accept
 
-Our OS X build script uses `the Homebrew <https://brew.sh>`_
-package manager for installing external dependencies.
-Here's how to `uninstall Homebrew
-<https://docs.brew.sh/FAQ#how-do-i-uninstall-homebrew>`_,
-if you ever want to start again from scratch.
+Nuestro script de compilación para OS X usa el gestor de paquetes 
+`Homebrew <https://brew.sh>`_ para instalar dependencias externas. 
+Aquí puede ver cómo `desinstalar Homebrew
+<https://docs.brew.sh/FAQ#how-do-i-uninstall-homebrew>`_, si necesita
+empezar desde cero.
 
-Prerequisites - Windows
+Prerrequisitos - Windows
 -----------------------
 
-You need to install the following dependencies for Windows builds of Solidity:
+Necesitará instalar las siguientes dependencias para compilar Solidity en Windows:
 
 +-----------------------------------+-------------------------------------------------------+
-| Software                          | Notes                                                 |
+| Software                          | Notas                                                 |
 +===================================+=======================================================+
-| `Visual Studio 2019 Build Tools`_ | C++ compiler                                          |
+| `Visual Studio 2019 Build Tools`_ | Compilador de C++                                     |
 +-----------------------------------+-------------------------------------------------------+
-| `Visual Studio 2019`_  (Optional) | C++ compiler and dev environment.                     |
+| `Visual Studio 2019`_  (Opcional) | Compilador de C++ y entorno de desarrollo             |
 +-----------------------------------+-------------------------------------------------------+
-| `Boost`_ (version 1.77+)          | C++ libraries.                                        |
+| `Boost`_ (versión 1.77+)          | Librerías de C++                                      |
 +-----------------------------------+-------------------------------------------------------+
 
-If you already have one IDE and only need the compiler and libraries,
-you could install Visual Studio 2019 Build Tools.
+Si ya tiene un IDE y sólo necesita instalar el compilador y las librerías, puede instalar
+solamente Visual Studio 2019 Build Tools.
 
-Visual Studio 2019 provides both IDE and necessary compiler and libraries.
-So if you have not got an IDE and prefer to develop Solidity, Visual Studio 2019
-may be a choice for you to get everything setup easily.
+Visual Studio 2019 provee un IDE y el compilador y librerías necesarias.
+Si usted todavía no cuenta con un IDE de su preferencia y desea programar en Solidity,
+Visual Studio 2019 puede ser una opción para configurar todo de manera sencilla.
 
-Here is the list of components that should be installed
-in Visual Studio 2019 Build Tools or Visual Studio 2019:
+A continuación, una lista de componentes que deben ser instalados ya sea que use
+Visual Studio 2019 o Visual Studio 2019 Build Tools.
 
 * Visual Studio C++ core features
 * VC++ 2019 v141 toolset (x86,x64)
@@ -419,50 +429,51 @@ in Visual Studio 2019 Build Tools or Visual Studio 2019:
 .. _Visual Studio 2019: https://www.visualstudio.com/vs/
 .. _Visual Studio 2019 Build Tools: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019
 
-We have a helper script which you can use to install all required external dependencies:
+Tenemos un script de soporte que puede usar para instalar todas las dependencias externas necesarias:
 
 .. code-block:: bat
 
     scripts\install_deps.ps1
 
-This will install ``boost`` and ``cmake`` to the ``deps`` subdirectory.
+Esto instalará ``boost`` y ``cmake`` al subdirectorio ``deps``.
 
-Clone the Repository
---------------------
+Clonar el repositorio
+---------------------
 
-To clone the source code, execute the following command:
+Para clonar el código fuente ejecute el siguiente comando:
 
 .. code-block:: bash
 
     git clone --recursive https://github.com/ethereum/solidity.git
     cd solidity
 
-If you want to help developing Solidity,
-you should fork Solidity and add your personal fork as a second remote:
+Si usted quiere ayudar en el desarrollo de Solidity, le recomendamos 
+hacer 'fork' de Solidity y añadir su 'fork' personal como segundo remoto:
 
 .. code-block:: bash
 
     git remote add personal git@github.com:[username]/solidity.git
 
-.. note::
-    This method will result in a prerelease build leading to e.g. a flag
-    being set in each bytecode produced by such a compiler.
-    If you want to re-build a released Solidity compiler, then
-    please use the source tarball on the github release page:
+.. Nota::
+    Este método generará una precompilación que llevará a, por ejemplo,
+    que se genere una bandera en cada bytecode producido por el compilador.
+    Si quiere recompilar un compilador de Solidity ya lanzado, por favor
+    use el archivo tarball en la página de lanzamientos de github:
 
     https://github.com/ethereum/solidity/releases/download/v0.X.Y/solidity_0.X.Y.tar.gz
 
-    (not the "Source code" provided by github).
+    (no el "código fuente" de github).
 
-Command-Line Build
-------------------
+Compilación por la línea de comandos
+------------------------------------
 
-**Be sure to install External Dependencies (see above) before build.**
+**Asegúrese de instalar todas las dependencias externas (ver arriba) antes de compilar.**
 
-Solidity project uses CMake to configure the build.
-You might want to install `ccache`_ to speed up repeated builds.
-CMake will pick it up automatically.
-Building Solidity is quite similar on Linux, macOS and other Unices:
+El proyecto de Solidity utiliza CMake para configurar la compilación.
+Se recomienda instalar `ccache`_ para acelerar el proceso si requiere compilar
+en repetidas ocasiones.
+CMake lo detectará automaticamente.
+Compilar Solidity es bastante parecido en Linux, macOS y otras versiones de Unix:
 
 .. _ccache: https://ccache.dev/
 
@@ -472,18 +483,18 @@ Building Solidity is quite similar on Linux, macOS and other Unices:
     cd build
     cmake .. && make
 
-or even easier on Linux and macOS, you can run:
+En Linux y macOS es todavía más fácil, puede correr:
 
 .. code-block:: bash
 
-    #note: this will install binaries solc and soltest at usr/local/bin
+    #nota: esto instalará los binarios solc y soltest en usr/local/bin
     ./scripts/build.sh
 
-.. warning::
+.. Advertencia::
 
-    BSD builds should work, but are untested by the Solidity team.
+    Las compilaciones en BSD deberían funcionar, pero no han sido probadas por el equipo de Solidity.
 
-And for Windows:
+Y para Windows:
 
 .. code-block:: bash
 
@@ -491,81 +502,82 @@ And for Windows:
     cd build
     cmake -G "Visual Studio 16 2019" ..
 
-In case you want to use the version of boost installed by ``scripts\install_deps.ps1``, you will
-additionally need to pass ``-DBoost_DIR="deps\boost\lib\cmake\Boost-*"`` and ``-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded``
-as arguments to the call to ``cmake``.
+En caso de querer usar la versión de boost instalada por ``scripts\install_deps.ps1``, deberá 
+pasar adicionalmente las banderas ``-DBoost_DIR="deps\boost\lib\cmake\Boost-*"`` y 
+``-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`` como argumentos cuando corra ``cmake``.
 
-This should result in the creation of **solidity.sln** in that build directory.
-Double-clicking on that file should result in Visual Studio firing up.  We suggest building
-**Release** configuration, but all others work.
+Esto debería crear un archivo **solidity.sln** en ese directorio. Al hacer doble click 
+en ese archivo Visual Studio debería abrirse. Sugerimos compilar con la configuración 
+**Release** pero todas las demás funcionan.
 
-Alternatively, you can build for Windows on the command-line, like so:
+De manera alternativa, puede compilar en Windows desde la línea de comandos:
 
 .. code-block:: bash
 
     cmake --build . --config Release
 
-CMake Options
-=============
+Opciones de CMake
+=================
 
-If you are interested what CMake options are available run ``cmake .. -LH``.
+Para ver las opciones de Cmake disponibles solo corra ``cmake .. -LH``.
 
 .. _smt_solvers_build:
 
-SMT Solvers
------------
-Solidity can be built against SMT solvers and will do so by default if
-they are found in the system. Each solver can be disabled by a `cmake` option.
+Solvers de SMT
+--------------
+Solidity puede ser compilado contra solvers SMT y lo hará por defecto 
+si se encuentran en el sistema. Cada solver puede ser deshabilitado con una 
+opción de `cmake`.
 
-*Note: In some cases, this can also be a potential workaround for build failures.*
+*Nota: En algunos casos, esto también puede ser una solución alterna para compilaciones fallidas.*
 
-
-Inside the build folder you can disable them, since they are enabled by default:
+En la carpeta donde compile puede deshabilitarlos, ya que están habilitados por defecto:
 
 .. code-block:: bash
 
-    # disables only Z3 SMT Solver.
+    # deshabilita solo el solver SMT para Z3
     cmake .. -DUSE_Z3=OFF
 
-    # disables only CVC4 SMT Solver.
+    # deshabilita solo el solver SMT para CVC4
     cmake .. -DUSE_CVC4=OFF
 
-    # disables both Z3 and CVC4
+    # deshabilita los solvers para CVC4 y Z3
     cmake .. -DUSE_CVC4=OFF -DUSE_Z3=OFF
 
-The Version String in Detail
-============================
+La Cadena de Versión en Detalle
+===============================
 
-The Solidity version string contains four parts:
+La cadena de versión de Solidity contiene cuatro partes:
 
-- the version number
-- pre-release tag, usually set to ``develop.YYYY.MM.DD`` or ``nightly.YYYY.MM.DD``
-- commit in the format of ``commit.GITHASH``
-- platform, which has an arbitrary number of items, containing details about the platform and compiler
+- el número de versión
+- la etiqueta de pre-release, generalmente fijada en ``develop.YYYY.MM.DD`` o ``nightly.YYYY.MM.DD``
+- commit en el formato ``commit.GITHASH``
+- la plataforma, que contiene un número arbitrario de elementos, e incluye detalles sobre la plataforma y el compilador
 
-If there are local modifications, the commit will be postfixed with ``.mod``.
+Si hay modificaciones locales, el commit tendrá el sufijo de ``.mod``.
 
-These parts are combined as required by SemVer, where the Solidity pre-release tag equals to the SemVer pre-release
-and the Solidity commit and platform combined make up the SemVer build metadata.
+Estas partes se combinan según requerimientos de SemVer, donde la etiqueta de pre-release de Solidity equivale al 
+pre-release de SemVer y el commit de Solidity y la plataforma combinados nos dan la metadata del compilado de SemVer.
 
-A release example: ``0.4.8+commit.60cc1668.Emscripten.clang``.
+Un ejemplo de release: ``0.4.8+commit.60cc1668.Emscripten.clang``.
 
-A pre-release example: ``0.4.9-nightly.2017.1.17+commit.6ecb4aa3.Emscripten.clang``
+Un ejemplo de pre-release: ``0.4.9-nightly.2017.1.17+commit.6ecb4aa3.Emscripten.clang``
 
-Important Information About Versioning
-======================================
+Información Importante Sobre el Versionado
+==========================================
 
-After a release is made, the patch version level is bumped, because we assume that only
-patch level changes follow. When changes are merged, the version should be bumped according
-to SemVer and the severity of the change. Finally, a release is always made with the version
-of the current nightly build, but without the ``prerelease`` specifier.
+Después de que se hace un lanzamiento, se aumenta el número de versión de parche, porque asumimos
+que solo siguen cambios a nivel de parches. Cuando los cambios se fusionan, la versión debería ser
+aumentada de acuerdo a SemVer y a la severidad del cambio. Finalmente, un lanzamiento siempre se hace 
+con la versión de la compilación nocturna vigente, pero sin el especificador de ``prerelease``.
 
-Example:
+Ejemplo:
 
-1. The 0.4.0 release is made.
-2. The nightly build has a version of 0.4.1 from now on.
-3. Non-breaking changes are introduced --> no change in version.
-4. A breaking change is introduced --> version is bumped to 0.5.0.
-5. The 0.5.0 release is made.
+1. Se hace el release de la versión 0.4.0.
+2. La compilación nocturna tiene una versión de 0.4.1 de ahora en adelante.
+3. Se introducen cambios sin rupturas --> no hay cambio en la versión.
+4. Se introduce un cambio con rupturas --> la versión se aumenta a 0.5.0.
+5. Se hace el release de la versión 0.5.0.
 
-This behaviour works well with the  :ref:`version pragma <version_pragma>`.
+
+Este método funciona bien con la :ref:`versión de pragma <version_pragma>`.

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -57,7 +57,7 @@ completa, ``solc``. El uso de ``solcjs`` está documentado dentro de su propio
 Nota: El proyecto solc-js fue extraído del programa `solc` escrito en C++ usando Emscripten, lo
 que significa que ambos usan el mismo código fuente.
 `solc-js` puede usarse directamente en proyectos JavaScript (como Remix).
-Por favor dirígase al repositorio de solc-js para más instrucciones.
+Por favor diríjase al repositorio de solc-js para más instrucciones.
 
 .. code-block:: bash
 
@@ -159,7 +159,7 @@ con los cambios más recientes, por favor utilice el siguiente comando:
 .. Nota::
 
     El snap de ``solc`` usa confinamiento estricto. Este es el modo más seguro para paquetes
-    de snap pero tiene sus limitaciones, como por ejemplo, el sólo acceder a los archivos en sus
+    de snap pero tiene sus limitaciones, como por ejemplo, el solo acceder a los archivos en sus
     directorios ``/home`` y ``/media``.
     Para más información, vaya a `Demystifying Snap Confinement <https://snapcraft.io/blog/demystifying-snap-confinement>`_.
 
@@ -277,7 +277,7 @@ Esto significa que:
    contiene algunos elementos descontinuados que debería evitar usar al crear herramientas nuevas: 
    
    - Use ``emscripten-wasm32/`` (o en su defecto ``emscripten-asmjs/``) en lugar de ``bin/`` si 
-     quiere el mejor rendimiento. Hasta la versión 0.6.1 sólo proveíamos binarios de asm.js.
+     quiere el mejor rendimiento. Hasta la versión 0.6.1 solo proveíamos binarios de asm.js.
      A partir de la versión 0.6.2 hicimos el cambio a `WebAssembly builds`_ que tiene mucho mejor 
      rendimiento. Hemos recompilado las versiones más antiguas para wasm pero los archivos originales 
      asm.js se mantienen en ``bin/``. Los nuevos tuvieron que ser puestos en un directorio separado 
@@ -410,7 +410,7 @@ Necesitará instalar las siguientes dependencias para compilar Solidity en Windo
 | `Boost`_ (versión 1.77+)          | Librerías de C++                                      |
 +-----------------------------------+-------------------------------------------------------+
 
-Si ya tiene un IDE y sólo necesita instalar el compilador y las librerías, puede instalar
+Si ya tiene un IDE y solo necesita instalar el compilador y las librerías, puede instalar
 solamente Visual Studio 2019 Build Tools.
 
 Visual Studio 2019 provee un IDE y el compilador y librerías necesarias.


### PR DESCRIPTION
Most things were straightforward, terms were I had doubts I researched in other documentations like Reacts', Ubuntu, Homebrew for context of how specific terms are handled.

For directives 'Note' and 'Warning' I'm not sure how the rst parser knows how to interpret them in spanish, but I followed the approach I saw already in the repo and switched `.. note::` to `.. Nota::` and `.. warning::` to `.. Advertencia::`. 